### PR TITLE
swap out wcwidth for unicode-width

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ name = "term-table"
 version = "1.1.0"
 authors = ["Ryan Bluth <ryanbluth93@gmail.com>"]
 description = "Tables for CLI apps"
-license = "MIT" 
+license = "MIT"
 repository = "https://github.com/RyanBluth/term-table-rs"
 readme = "README.md"
 categories = ["command-line-interface"]
 keywords = ["table", "cli", "terminal"]
 
 [dependencies]
-"wcwidth" = "1.0.1"
-"regex" = "1.0.1"
-lazy_static = "1.0"
+lazy_static = "1"
+regex = "1"
+unicode-width = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 extern crate lazy_static;
 
 extern crate regex;
-extern crate wcwidth;
+extern crate unicode_width;
 
 pub mod row;
 pub mod table_cell;
@@ -692,7 +692,7 @@ mod test {
 
         add_data_to_test_table(&mut table);
 
-        let expected = 
+        let expected =
 "╭─────────────────────────────────────────────────────────────────────────────────╮
 │                            This is some centered text                           │
 ├────────────────────────────────────────┬────────────────────────────────────────┤
@@ -748,7 +748,7 @@ mod test {
             Alignment::Left,
         )]));
 
-        let expected = 
+        let expected =
 "╔═══════════════════════════════════════════════════════════════╦═══════════════════════════════╦═════════════════╦════════════════╦══╗
 ║ Col*1*Span*2                                                  ║ Col 2 Span 1                  ║ Col 3 Span 2    ║ Col 4 Span 1   ║  ║
 ╠═══════════════════════════════╦═══════════════════════════════╬═══════════════════════════════╬═════════════════╬════════════════╬══╣

--- a/src/row.rs
+++ b/src/row.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 use table_cell::{string_width, Alignment, TableCell};
-use wcwidth::char_width;
+use unicode_width::UnicodeWidthChar;
 use {RowPosition, TableStyle};
 
 /// A set of table cells
@@ -100,7 +100,7 @@ impl<'data> Row<'data> {
                             padding += cell_span - str_width;
                             // If the cols_span is greater than one we need to add extra padding for the missing vertical characters
                             if cell.col_span > 1 {
-                                padding += char_width(style.vertical).unwrap_or_default() as usize
+                                padding += style.vertical.width().unwrap_or_default()
                                     * (cell.col_span - 1); // Subtract one since we add a vertical character to the beginning
                             }
                         }

--- a/src/table_cell.rs
+++ b/src/table_cell.rs
@@ -1,8 +1,9 @@
 use regex::Regex;
-use std::borrow::Borrow;
 use std::borrow::Cow;
 use std::cmp;
-use wcwidth::{char_width, str_width};
+
+use unicode_width::UnicodeWidthChar;
+use unicode_width::UnicodeWidthStr;
 
 /// Represents the horizontal alignment of content within a cell.
 #[derive(Clone, Copy)]
@@ -89,7 +90,7 @@ impl<'data> TableCell<'data> {
             max = cmp::max(max, str_width);
         }
         return max + if self.pad_content {
-            2 * char_width(' ').unwrap_or(1) as usize
+            2 * ' '.width().unwrap_or(1) as usize
         } else {
             0
         };
@@ -105,10 +106,10 @@ impl<'data> TableCell<'data> {
     pub fn min_width(&self) -> usize {
         let mut max_char_width: usize = 0;
         for c in self.data.chars() {
-            max_char_width = cmp::max(max_char_width, char_width(c).unwrap_or(1) as usize);
+            max_char_width = cmp::max(max_char_width, c.width().unwrap_or(1) as usize);
         }
         return if self.pad_content {
-            max_char_width + char_width(' ').unwrap_or(1) as usize * 2
+            max_char_width + ' '.width().unwrap_or(1) as usize * 2
         } else {
             max_char_width
         };
@@ -123,7 +124,7 @@ impl<'data> TableCell<'data> {
         let mut buf = String::new();
         buf.push(pad_char);
         for c in self.data.chars().enumerate() {
-            if string_width(&buf) as usize >= width - char_width(pad_char).unwrap_or(1) as usize
+            if string_width(&buf) as usize >= width - pad_char.width().unwrap_or(1) as usize
                 || c.1 == '\n'
             {
                 buf.push(pad_char);
@@ -161,5 +162,5 @@ lazy_static! {
 // The width of a string. Strips ansi characters
 pub fn string_width(string: &str) -> usize {
     let stripped = STRIP_ANSI_RE.replace_all(string, "");
-    return str_width(stripped.borrow()).unwrap_or_default();
+    return stripped.width();
 }


### PR DESCRIPTION
Unfortunately, @lucy has decided to yank all versions of `wcwidth`, so the build now fails.

Flip over to `unicode-width`, which seems to be equivalent. Tests are green, example looks fine for me.