### PR TITLE
Fix using colors in table

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,6 +470,7 @@ impl<'data> Table<'data> {
                 for i in col_index..col_index + cell.col_span {
                     total_col_width += max_widths[i];
                 }
+                
                 if cell.width() != total_col_width
                     && cell.alignment == Alignment::Center
                     && total_col_width as f32 % 2.0 <= 0.001
@@ -1130,7 +1131,7 @@ r"+-----------------------------------------------------------------------------
     #[test]
     fn colored_data_works() {
         let mut table = Table::new();
-        table.add_row(Row::new(vec![TableCell::new("\x1b[31ma\x1b[0m")]));
+        table.add_row(Row::new(vec![TableCell::new("\u{1b}[31ma\u{1b}[0m")]));
         let expected = "╔═══╗
 ║ \u{1b}[31ma\u{1b}[0m ║
 ╚═══╝

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,13 +470,12 @@ impl<'data> Table<'data> {
                 for i in col_index..col_index + cell.col_span {
                     total_col_width += max_widths[i];
                 }
-                
                 if cell.width() != total_col_width
                     && cell.alignment == Alignment::Center
                     && total_col_width as f32 % 2.0 <= 0.001
                 {
                     let mut max_col_width = self.max_column_width;
-                    if let Some(specific_width) = self.max_column_widths.get(&col_index){
+                    if let Some(specific_width) = self.max_column_widths.get(&col_index) {
                         max_col_width = *specific_width;
                     }
 
@@ -484,9 +483,9 @@ impl<'data> Table<'data> {
                         max_widths[col_index] += 1;
                     }
                 }
-                if cell.col_span > 1{
+                if cell.col_span > 1 {
                     col_index += cell.col_span - 1;
-                }else{
+                } else {
                     col_index += 1;
                 }
             }
@@ -607,7 +606,7 @@ mod test {
     use crate::Table;
     use crate::TableBuilder;
     use crate::TableStyle;
-    use pretty_assertions::{assert_eq};
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn correct_default_padding() {
@@ -666,8 +665,7 @@ mod test {
             TableCell::new_with_alignment("B", 1, Alignment::Center),
         ]));
         println!("{}", table.render());
-        let expected = 
-r"+----+---+
+        let expected = r"+----+---+
 | A1 | B |
 +----+---+
 ";
@@ -681,8 +679,7 @@ r"+----+---+
 
         add_data_to_test_table(&mut table);
 
-        let expected = 
-r"+---------------------------------------------------------------------------------+
+        let expected = r"+---------------------------------------------------------------------------------+
 |                            This is some centered text                           |
 +----------------------------------------+----------------------------------------+
 | This is left aligned text              |             This is right aligned text |
@@ -708,10 +705,16 @@ r"+-----------------------------------------------------------------------------
         ]));
         table.add_row(Row::new(vec![TableCell::new(1), TableCell::new("1")]));
         table.add_row(Row::new(vec![TableCell::new(2), TableCell::new("10")]));
-        table.add_row(Row::new(vec![TableCell::new_with_alignment_and_padding(3, 1, Alignment::Left, false), TableCell::new("100")]));
-        table.add_row(Row::new(vec![TableCell::new_with_alignment("S", 2, Alignment::Center)]));
-        let expected = 
-"+----------+-----+
+        table.add_row(Row::new(vec![
+            TableCell::new_with_alignment_and_padding(3, 1, Alignment::Left, false),
+            TableCell::new("100"),
+        ]));
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "S",
+            2,
+            Alignment::Center,
+        )]));
+        let expected = "+----------+-----+
 | A1111111 |  B  |
 +----------+-----+
 | 1        | 1   |
@@ -741,9 +744,12 @@ r"+-----------------------------------------------------------------------------
         table.add_row(Row::new(vec![TableCell::new(1), TableCell::new("1")]));
         table.add_row(Row::new(vec![TableCell::new(2), TableCell::new("10")]));
         table.add_row(Row::new(vec![TableCell::new(3), TableCell::new("100")]));
-        table.add_row(Row::new(vec![TableCell::new_with_alignment("Spanner", 2, Alignment::Center)]));
-        let expected = 
-"+------+-----+
+        table.add_row(Row::new(vec![TableCell::new_with_alignment(
+            "Spanner",
+            2,
+            Alignment::Center,
+        )]));
+        let expected = "+------+-----+
 |   A  |  B  |
 | 1    | 1   |
 | 2    | 10  |
@@ -754,7 +760,6 @@ r"+-----------------------------------------------------------------------------
         println!("{}", table.render());
         assert_eq!(expected.trim(), table.render().trim());
     }
-
 
     #[test]
     fn extended_table_style_wrapped() {
@@ -785,8 +790,7 @@ r"+-----------------------------------------------------------------------------
             TableCell::new_with_col_span("This is some really really really really really really really really really that is going to wrap to the next line\n1\n2", 2),
         ]));
 
-        let expected = 
-r"╔═══════╗
+        let expected = r"╔═══════╗
 ║ This  ║
 ║ is so ║
 ║ me ce ║
@@ -879,7 +883,6 @@ r"╔═══════╗
         assert_eq!(expected, table.render());
     }
 
-    
     #[test]
     fn elegant_table_style() {
         let mut table = Table::new();
@@ -887,8 +890,7 @@ r"╔═══════╗
 
         add_data_to_test_table(&mut table);
 
-        let expected = 
-r"╔─────────────────────────────────────────────────────────────────────────────────╗
+        let expected = r"╔─────────────────────────────────────────────────────────────────────────────────╗
 │                            This is some centered text                           │
 ╠────────────────────────────────────────╦────────────────────────────────────────╣
 │ This is left aligned text              │             This is right aligned text │
@@ -910,8 +912,7 @@ r"╔─────────────────────────
 
         add_data_to_test_table(&mut table);
 
-        let expected = 
-r"┌─────────────────────────────────────────────────────────────────────────────────┐
+        let expected = r"┌─────────────────────────────────────────────────────────────────────────────────┐
 │                            This is some centered text                           │
 ├────────────────────────────────────────┬────────────────────────────────────────┤
 │ This is left aligned text              │             This is right aligned text │
@@ -934,8 +935,7 @@ r"┌─────────────────────────
 
         add_data_to_test_table(&mut table);
 
-        let expected = 
-r"╭─────────────────────────────────────────────────────────────────────────────────╮
+        let expected = r"╭─────────────────────────────────────────────────────────────────────────────────╮
 │                            This is some centered text                           │
 ├────────────────────────────────────────┬────────────────────────────────────────┤
 │ This is left aligned text              │             This is right aligned text │
@@ -1045,8 +1045,7 @@ r"╭─────────────────────────
 
         add_data_to_test_table(&mut table);
 
-        let expected =
-r"|                            This is some centered text                           |
+        let expected = r"|                            This is some centered text                           |
 +----------------------------------------+----------------------------------------+
 | This is left aligned text              |             This is right aligned text |
 +----------------------------------------+----------------------------------------+
@@ -1068,8 +1067,7 @@ r"|                            This is some centered text                       
 
         add_data_to_test_table(&mut table);
 
-        let expected = 
-r"+---------------------------------------------------------------------------------+
+        let expected = r"+---------------------------------------------------------------------------------+
 |                            This is some centered text                           |
 +----------------------------------------+----------------------------------------+
 | This is left aligned text              |             This is right aligned text |
@@ -1091,8 +1089,7 @@ r"+-----------------------------------------------------------------------------
 
         add_data_to_test_table(&mut table);
 
-        let expected = 
-r"+---------------------------------------------------------------------------------+
+        let expected = r"+---------------------------------------------------------------------------------+
 |                            This is some centered text                           |
 | This is left aligned text              |             This is right aligned text |
 | This is left aligned text              |             This is right aligned text |
@@ -1113,8 +1110,7 @@ r"+-----------------------------------------------------------------------------
 
         table.rows[2].has_separator = false;
 
-        let expected = 
-r"+---------------------------------------------------------------------------------+
+        let expected = r"+---------------------------------------------------------------------------------+
 |                            This is some centered text                           |
 +----------------------------------------+----------------------------------------+
 | This is left aligned text              |             This is right aligned text |
@@ -1123,6 +1119,18 @@ r"+-----------------------------------------------------------------------------
 | This is some really really really really really really really really really tha |
 | t is going to wrap to the next line                                             |
 +---------------------------------------------------------------------------------+
+";
+        println!("{}", table.render());
+        assert_eq!(expected, table.render());
+    }
+
+    #[test]
+    fn colored_data_works() {
+        let mut table = Table::new();
+        table.add_row(Row::new(vec![TableCell::new("\x1b[31ma\x1b[0m")]));
+        let expected = "╔═══╗
+║ \u{1b}[31ma\u{1b}[0m ║
+╚═══╝
 ";
         println!("{}", table.render());
         assert_eq!(expected, table.render());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,7 +475,7 @@ impl<'data> Table<'data> {
                     && total_col_width as f32 % 2.0 <= 0.001
                 {
                     let mut max_col_width = self.max_column_width;
-                    if let Some(specific_width) = self.max_column_widths.get(&col_index) {
+                    if let Some(specific_width) = self.max_column_widths.get(&col_index){
                         max_col_width = *specific_width;
                     }
 
@@ -483,9 +483,9 @@ impl<'data> Table<'data> {
                         max_widths[col_index] += 1;
                     }
                 }
-                if cell.col_span > 1 {
+                if cell.col_span > 1{
                     col_index += cell.col_span - 1;
-                } else {
+                }else{
                     col_index += 1;
                 }
             }
@@ -606,7 +606,7 @@ mod test {
     use crate::Table;
     use crate::TableBuilder;
     use crate::TableStyle;
-    use pretty_assertions::assert_eq;
+    use pretty_assertions::{assert_eq};
 
     #[test]
     fn correct_default_padding() {
@@ -665,7 +665,8 @@ mod test {
             TableCell::new_with_alignment("B", 1, Alignment::Center),
         ]));
         println!("{}", table.render());
-        let expected = r"+----+---+
+        let expected = 
+r"+----+---+
 | A1 | B |
 +----+---+
 ";
@@ -679,7 +680,8 @@ mod test {
 
         add_data_to_test_table(&mut table);
 
-        let expected = r"+---------------------------------------------------------------------------------+
+        let expected = 
+r"+---------------------------------------------------------------------------------+
 |                            This is some centered text                           |
 +----------------------------------------+----------------------------------------+
 | This is left aligned text              |             This is right aligned text |
@@ -705,16 +707,10 @@ mod test {
         ]));
         table.add_row(Row::new(vec![TableCell::new(1), TableCell::new("1")]));
         table.add_row(Row::new(vec![TableCell::new(2), TableCell::new("10")]));
-        table.add_row(Row::new(vec![
-            TableCell::new_with_alignment_and_padding(3, 1, Alignment::Left, false),
-            TableCell::new("100"),
-        ]));
-        table.add_row(Row::new(vec![TableCell::new_with_alignment(
-            "S",
-            2,
-            Alignment::Center,
-        )]));
-        let expected = "+----------+-----+
+        table.add_row(Row::new(vec![TableCell::new_with_alignment_and_padding(3, 1, Alignment::Left, false), TableCell::new("100")]));
+        table.add_row(Row::new(vec![TableCell::new_with_alignment("S", 2, Alignment::Center)]));
+        let expected = 
+"+----------+-----+
 | A1111111 |  B  |
 +----------+-----+
 | 1        | 1   |
@@ -744,12 +740,9 @@ mod test {
         table.add_row(Row::new(vec![TableCell::new(1), TableCell::new("1")]));
         table.add_row(Row::new(vec![TableCell::new(2), TableCell::new("10")]));
         table.add_row(Row::new(vec![TableCell::new(3), TableCell::new("100")]));
-        table.add_row(Row::new(vec![TableCell::new_with_alignment(
-            "Spanner",
-            2,
-            Alignment::Center,
-        )]));
-        let expected = "+------+-----+
+        table.add_row(Row::new(vec![TableCell::new_with_alignment("Spanner", 2, Alignment::Center)]));
+        let expected = 
+"+------+-----+
 |   A  |  B  |
 | 1    | 1   |
 | 2    | 10  |
@@ -760,6 +753,7 @@ mod test {
         println!("{}", table.render());
         assert_eq!(expected.trim(), table.render().trim());
     }
+
 
     #[test]
     fn extended_table_style_wrapped() {
@@ -790,7 +784,8 @@ mod test {
             TableCell::new_with_col_span("This is some really really really really really really really really really that is going to wrap to the next line\n1\n2", 2),
         ]));
 
-        let expected = r"╔═══════╗
+        let expected = 
+r"╔═══════╗
 ║ This  ║
 ║ is so ║
 ║ me ce ║
@@ -883,6 +878,7 @@ mod test {
         assert_eq!(expected, table.render());
     }
 
+    
     #[test]
     fn elegant_table_style() {
         let mut table = Table::new();
@@ -890,7 +886,8 @@ mod test {
 
         add_data_to_test_table(&mut table);
 
-        let expected = r"╔─────────────────────────────────────────────────────────────────────────────────╗
+        let expected = 
+r"╔─────────────────────────────────────────────────────────────────────────────────╗
 │                            This is some centered text                           │
 ╠────────────────────────────────────────╦────────────────────────────────────────╣
 │ This is left aligned text              │             This is right aligned text │
@@ -912,7 +909,8 @@ mod test {
 
         add_data_to_test_table(&mut table);
 
-        let expected = r"┌─────────────────────────────────────────────────────────────────────────────────┐
+        let expected = 
+r"┌─────────────────────────────────────────────────────────────────────────────────┐
 │                            This is some centered text                           │
 ├────────────────────────────────────────┬────────────────────────────────────────┤
 │ This is left aligned text              │             This is right aligned text │
@@ -935,7 +933,8 @@ mod test {
 
         add_data_to_test_table(&mut table);
 
-        let expected = r"╭─────────────────────────────────────────────────────────────────────────────────╮
+        let expected = 
+r"╭─────────────────────────────────────────────────────────────────────────────────╮
 │                            This is some centered text                           │
 ├────────────────────────────────────────┬────────────────────────────────────────┤
 │ This is left aligned text              │             This is right aligned text │
@@ -1045,7 +1044,8 @@ mod test {
 
         add_data_to_test_table(&mut table);
 
-        let expected = r"|                            This is some centered text                           |
+        let expected =
+r"|                            This is some centered text                           |
 +----------------------------------------+----------------------------------------+
 | This is left aligned text              |             This is right aligned text |
 +----------------------------------------+----------------------------------------+
@@ -1067,7 +1067,8 @@ mod test {
 
         add_data_to_test_table(&mut table);
 
-        let expected = r"+---------------------------------------------------------------------------------+
+        let expected = 
+r"+---------------------------------------------------------------------------------+
 |                            This is some centered text                           |
 +----------------------------------------+----------------------------------------+
 | This is left aligned text              |             This is right aligned text |
@@ -1089,7 +1090,8 @@ mod test {
 
         add_data_to_test_table(&mut table);
 
-        let expected = r"+---------------------------------------------------------------------------------+
+        let expected = 
+r"+---------------------------------------------------------------------------------+
 |                            This is some centered text                           |
 | This is left aligned text              |             This is right aligned text |
 | This is left aligned text              |             This is right aligned text |
@@ -1110,7 +1112,8 @@ mod test {
 
         table.rows[2].has_separator = false;
 
-        let expected = r"+---------------------------------------------------------------------------------+
+        let expected = 
+r"+---------------------------------------------------------------------------------+
 |                            This is some centered text                           |
 +----------------------------------------+----------------------------------------+
 | This is left aligned text              |             This is right aligned text |


### PR DESCRIPTION
I believe the issue is in [`TableCell::wrapped_content`](https://github.com/RyanBluth/term-table-rs/blob/d81331944f4b8c4bbac7435cd4921733e5b45e64/src/table_cell.rs#L125-L138), we are looping over each char to see if content should be wrapped, but for escape sequences, each char may not display in the terminal. Still pondering how best to fix this, open to suggestions and edits.

Just realized rust formatter changed some stuff, i'll revert that later to minimize the diff, this commit only adds a basic test I used for debugging.

Closes #6