### PR TITLE
Fix rendering of newline characters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1167,6 +1167,39 @@ mod test {
         assert_eq!(expected, table.render());
     }
 
+    #[test]
+    fn works_with_different_new_line_chars() {
+        let mut table = Table::new();
+        let input = "Hello there!\r\n\r\nHere is a longer paragraph:\r\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\r\n\r\nIf you have any suggestions, please feel free to open an issue.\r\n\r\nBye 👋 ";
+        table.add_row(Row::new(vec![TableCell::new(input)]));
+        table.max_column_width(40);
+        let expected = "╔════════════════════════════════════════╗
+║ Hello there!                           ║
+║                                        ║
+║ Here is a longer paragraph:            ║
+║ Lorem ipsum dolor sit amet, consectetu ║
+║ r adipiscing elit, sed do eiusmod temp ║
+║ or incididunt ut labore et dolore magn ║
+║ a aliqua. Ut enim ad minim veniam, qui ║
+║ s nostrud exercitation ullamco laboris ║
+║  nisi ut aliquip ex ea commodo consequ ║
+║ at. Duis aute irure dolor in reprehend ║
+║ erit in voluptate velit esse cillum do ║
+║ lore eu fugiat nulla pariatur. Excepte ║
+║ ur sint occaecat cupidatat non proiden ║
+║ t, sunt in culpa qui officia deserunt  ║
+║ mollit anim id est laborum.            ║
+║                                        ║
+║ If you have any suggestions, please fe ║
+║ el free to open an issue.              ║
+║                                        ║
+║ Bye 👋                                 ║
+╚════════════════════════════════════════╝
+";
+        println!("{}", table.render());
+        assert_eq!(expected, table.render());
+    }
+
     fn add_data_to_test_table(table: &mut Table) {
         table.max_column_width = 40;
         table.add_row(Row::new(vec![TableCell::new_with_alignment(

--- a/src/table_cell.rs
+++ b/src/table_cell.rs
@@ -34,7 +34,7 @@ impl<'data> TableCell<'data> {
         T: ToString,
     {
         Self {
-            data: data.to_string().into(),
+            data: cleanup_newline_chars(data.to_string()).into(),
             col_span: 1,
             alignment: Alignment::Left,
             pad_content: true,
@@ -46,7 +46,7 @@ impl<'data> TableCell<'data> {
         T: ToString,
     {
         Self {
-            data: data.to_string().into(),
+            data: cleanup_newline_chars(data.to_string()).into(),
             alignment: Alignment::Left,
             pad_content: true,
             col_span,
@@ -58,7 +58,7 @@ impl<'data> TableCell<'data> {
         T: ToString,
     {
         Self {
-            data: data.to_string().into(),
+            data: cleanup_newline_chars(data.to_string()).into(),
             pad_content: true,
             col_span,
             alignment,
@@ -75,7 +75,7 @@ impl<'data> TableCell<'data> {
         T: ToString,
     {
         Self {
-            data: data.to_string().into(),
+            data: cleanup_newline_chars(data.to_string()).into(),
             col_span,
             alignment,
             pad_content,
@@ -171,4 +171,8 @@ lazy_static! {
 pub fn string_width(string: &str) -> usize {
     let stripped = STRIP_ANSI_RE.replace_all(string, "");
     stripped.width()
+}
+
+fn cleanup_newline_chars(input: String) -> String {
+    input.replace("\r\n", "\n").replace('\r', "\n")
 }


### PR DESCRIPTION
Rendering tables failed for me when I used data from some API that didn't match the expected newline character format of my OS. It looked like this

![image](https://user-images.githubusercontent.com/26892280/215261583-655c8ce8-f429-4ec3-a20d-67e2e67084fa.png)

To be specific, it had to do with the use of `\r\n` instead of `\n`. This PR fixes the issue for unix system users. I can't verify if the tables are rendered correctly under windows though.