### PR TITLE
Fixed clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,6 @@ impl TableStyle {
     /// │ t is going to wrap to the next line                                             │
     /// ╚─────────────────────────────────────────────────────────────────────────────────╝
     /// </pre>
-
     pub fn elegant() -> TableStyle {
         TableStyle {
             top_left_corner: '╔',
@@ -381,15 +380,15 @@ impl TableStyle {
         if (top == self.horizontal || top == self.outer_bottom_horizontal)
             && bottom == self.intersection
         {
-            return self.outer_top_horizontal;
+            self.outer_top_horizontal
         } else if (top == self.intersection || top == self.outer_top_horizontal)
             && bottom == self.horizontal
         {
-            return self.outer_bottom_horizontal;
+            self.outer_bottom_horizontal
         } else if top == self.outer_bottom_horizontal && bottom == self.horizontal {
-            return self.horizontal;
+            self.horizontal
         } else {
-            return self.intersect_for_position(pos);
+            self.intersect_for_position(pos)
         }
     }
 }
@@ -399,7 +398,7 @@ impl TableStyle {
 pub struct Table {
     pub rows: Vec<Row>,
     pub style: TableStyle,
-    /// The maximum width of all columns. Overridden by values in column_widths. Defaults to `std::usize::max`
+    /// The maximum width of all columns. Overridden by values in column_widths. Defaults to `usize::MAX`
     pub max_column_width: usize,
     /// The maximum widths of specific columns. Override max_column
     pub max_column_widths: HashMap<usize, usize>,
@@ -417,7 +416,7 @@ impl Table {
         Self {
             rows: Vec::new(),
             style: TableStyle::extended(),
-            max_column_width: std::usize::MAX,
+            max_column_width: usize::MAX,
             max_column_widths: HashMap::new(),
             separate_rows: true,
             has_top_boarder: true,
@@ -434,7 +433,7 @@ impl Table {
         Self {
             rows,
             style: TableStyle::extended(),
-            max_column_width: std::usize::MAX,
+            max_column_width: usize::MAX,
             max_column_widths: HashMap::new(),
             separate_rows: true,
             has_top_boarder: true,
@@ -508,7 +507,7 @@ impl Table {
                 Table::buffer_line(&mut print_buffer, &separator);
             }
         }
-        return print_buffer;
+        print_buffer
     }
 
     /// Calculates the maximum width for each column.
@@ -531,7 +530,7 @@ impl Table {
                     .max_column_widths
                     .get(&i)
                     .unwrap_or(&self.max_column_width);
-                max_width = max(min_widths[i] as usize, max_width);
+                max_width = max(min_widths[i], max_width);
                 max_widths[i] = min(max_width, max(max_widths[i], column_widths[i].0 as usize));
             }
         }
@@ -542,8 +541,8 @@ impl Table {
             let mut col_index = 0;
             for cell in row.cells.iter() {
                 let mut total_col_width = 0;
-                for i in col_index..col_index + cell.col_span {
-                    total_col_width += max_widths[i];
+                for max_width in max_widths.iter().skip(col_index).take(cell.col_span) {
+                    total_col_width += max_width;
                 }
                 if cell.width() != total_col_width
                     && cell.alignment == Alignment::Center
@@ -566,7 +565,7 @@ impl Table {
             }
         }
 
-        return max_widths;
+        max_widths
     }
 
     /// Helper method for adding a line to a string buffer
@@ -577,13 +576,13 @@ impl Table {
 
 impl Default for Table {
     fn default() -> Self {
-        return Table::new();
+        Table::new()
     }
 }
 
-impl ToString for Table {
-    fn to_string(&self) -> String {
-        return self.render();
+impl std::fmt::Display for Table {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.render())
     }
 }
 
@@ -604,7 +603,7 @@ impl TableBuilder {
         TableBuilder {
             rows: Vec::new(),
             style: TableStyle::extended(),
-            max_column_width: std::usize::MAX,
+            max_column_width: usize::MAX,
             max_column_widths: HashMap::new(),
             separate_rows: true,
             has_top_boarder: true,
@@ -622,7 +621,7 @@ impl TableBuilder {
         self
     }
 
-    /// The maximum width of all columns. Overridden by values in column_widths. Defaults to `std::usize::max`
+    /// The maximum width of all columns. Overridden by values in column_widths. Defaults to `usize::MAX`
     pub fn max_column_width(&mut self, max_column_width: usize) -> &mut Self {
         self.max_column_width = max_column_width;
         self

--- a/src/row.rs
+++ b/src/row.rs
@@ -85,7 +85,8 @@ impl Row {
 
         // We need to iterate over all of the column widths
         // We may not have as many cells as column widths, or the cells may not even span
-        // as many columns as are in column widths. In that case weill will create empty cells
+        // as many columns as are in column widths. In that case we will create empty cells
+        #[allow(clippy::needless_range_loop)] // col_idx indexes two vecs here
         for col_idx in 0..column_widths.len() {
             // Check to see if we actually have a cell for the column index
             // Otherwise we will just need to print out empty space as filler
@@ -299,16 +300,16 @@ impl Row {
     /// Pads a string accoding to the provided alignment
     fn pad_string(&self, padding: usize, alignment: Alignment, text: &str) -> String {
         match alignment {
-            Alignment::Left => return format!("{}{}", text, str::repeat(" ", padding)),
-            Alignment::Right => return format!("{}{}", str::repeat(" ", padding), text),
+            Alignment::Left => format!("{}{}", text, str::repeat(" ", padding)),
+            Alignment::Right => format!("{}{}", str::repeat(" ", padding), text),
             Alignment::Center => {
                 let half_padding = padding as f32 / 2.0;
-                return format!(
+                format!(
                     "{}{}{}",
                     str::repeat(" ", half_padding.ceil() as usize),
                     text,
                     str::repeat(" ", half_padding.floor() as usize)
-                );
+                )
             }
         }
     }

--- a/src/table_cell.rs
+++ b/src/table_cell.rs
@@ -95,7 +95,7 @@ impl TableCell {
     ///
     /// New line characters are taken into account during the calculation.
     pub fn width(&self) -> usize {
-        let wrapped = self.wrapped_content(std::usize::MAX);
+        let wrapped = self.wrapped_content(usize::MAX);
         let mut max = 0;
         for s in wrapped {
             let str_width = string_width(&s);
@@ -106,19 +106,18 @@ impl TableCell {
 
     /// The width of the cell's content divided by its `col_span` value.
     pub fn split_width(&self) -> f32 {
-        let res = self.width() as f32 / self.col_span as f32;
-        res
+        self.width() as f32 / self.col_span as f32
     }
 
     /// The minium width required to display the cell properly
     pub fn min_width(&self) -> usize {
         let mut max_char_width: usize = 0;
         for c in self.data.chars() {
-            max_char_width = cmp::max(max_char_width, c.width().unwrap_or(1) as usize);
+            max_char_width = cmp::max(max_char_width, c.width().unwrap_or(1));
         }
 
         if self.pad_content {
-            max_char_width + ' '.width().unwrap_or(1) as usize * 2
+            max_char_width + ' '.width().unwrap_or(1) * 2
         } else {
             max_char_width
         }
@@ -176,15 +175,15 @@ pub struct TableCellBuilder {
     pad_content: bool,
 }
 
-impl Into<TableCell> for TableCellBuilder {
-    fn into(self) -> TableCell {
-        self.build()
+impl From<TableCellBuilder> for TableCell {
+    fn from(val: TableCellBuilder) -> Self {
+        val.build()
     }
 }
 
-impl Into<TableCell> for &mut TableCellBuilder {
-    fn into(self) -> TableCell {
-        self.build()
+impl From<&mut TableCellBuilder> for TableCell {
+    fn from(val: &mut TableCellBuilder) -> Self {
+        val.build()
     }
 }
 


### PR DESCRIPTION
I fixed all clippy warnings, except for one. In file `row.rs` at line 90 it suggested a solution that I thought was a bit clunky so I kept the original code and added an allow. It wanted to loop through the vector instead of using an index but then *also* keep that very index to index into second vector.